### PR TITLE
Update path to faers data to point to 'significant' data.

### DIFF
--- a/terraform/modules/posvm/scripts/load_all_data.sh
+++ b/terraform/modules/posvm/scripts/load_all_data.sh
@@ -49,7 +49,7 @@ export ID="id"
 export INDEX_SETTINGS=$PREFIX_DATA/index_settings.json
 ./load_json_esbulk.sh
 
-# /faers/json/raw/*
+# /faers/json/significant/*
 export INDEX_NAME="openfda_faers"
 export INPUT=$PREFIX_DATA"faers"
 export ID=""

--- a/terraform/modules/posvm/scripts/load_data.sh
+++ b/terraform/modules/posvm/scripts/load_data.sh
@@ -23,7 +23,7 @@ mkdir -p /tmp/data/faers/
 echo "Copy from GS to local HD"
 gsutil -m cp -r gs://${GS_ETL_DATASET}/etl/json/* /tmp/data/
 gsutil -m cp -r gs://${GS_ETL_DATASET}/so/* /tmp/data/so
-gsutil -m cp -r gs://${GS_ETL_DATASET}/faers/json/raw/* /tmp/data/faers/
+gsutil -m cp -r gs://${GS_ETL_DATASET}/faers/json/significant/* /tmp/data/faers/
 
 sudo mkdir -p /tmp
 cd /tmp


### PR DESCRIPTION
The API requires the data grouped by ChEMBL ID which is the 'significant' dataset.

Resolves opentargets/platform#1602