### PR TITLE
trim whitespace from queries

### DIFF
--- a/terraform_create_images/scripts/posvm/postproduction/elasticsearch/index_settings/search.json
+++ b/terraform_create_images/scripts/posvm/postproduction/elasticsearch/index_settings/search.json
@@ -40,7 +40,7 @@
           "autocomplete_filter": {
             "type": "edge_ngram",
             "min_gram": 2,
-            "max_gram": 100,
+            "max_gram": 102,
             "token_chars": [
               "letter",
               "digit",


### PR DESCRIPTION
- as part of new feedback from opentargets/issues#3561
- "trim" filter added to the custom analyzer, "token", which is used for keyword multiMatch and simple string query at query time. This will strip leading and trailing whitespace from the query tokens. 