### PR TITLE
update l2g index, reduce number of shards for all elastic indices to 1, zero weight to field length in search

### DIFF
--- a/terraform_create_images/scripts/posvm/postproduction/elasticsearch/index_settings/colocalisation.json
+++ b/terraform_create_images/scripts/posvm/postproduction/elasticsearch/index_settings/colocalisation.json
@@ -64,7 +64,7 @@
     "settings": {
         "index": {
             "number_of_replicas": 0,
-            "number_of_shards": 5
+            "number_of_shards": 1
         }
     }
 }

--- a/terraform_create_images/scripts/posvm/postproduction/elasticsearch/index_settings/cred_set.json
+++ b/terraform_create_images/scripts/posvm/postproduction/elasticsearch/index_settings/cred_set.json
@@ -18,7 +18,7 @@
     "settings": {
         "index": {
             "number_of_replicas": 0,
-            "number_of_shards": 5,
+            "number_of_shards": 1,
             "mapping.nested_objects.limit": 11000,
             "max_inner_result_window": 11000
         }

--- a/terraform_create_images/scripts/posvm/postproduction/elasticsearch/index_settings/default.json
+++ b/terraform_create_images/scripts/posvm/postproduction/elasticsearch/index_settings/default.json
@@ -15,7 +15,7 @@
   "settings": {
     "index": {
       "number_of_replicas": 0,
-      "number_of_shards": 5
+      "number_of_shards": 1
     }
   }
 }

--- a/terraform_create_images/scripts/posvm/postproduction/elasticsearch/index_settings/facet_search.json
+++ b/terraform_create_images/scripts/posvm/postproduction/elasticsearch/index_settings/facet_search.json
@@ -43,7 +43,7 @@
     "settings": {
       "index": {
         "number_of_replicas": 0,
-        "number_of_shards": 5,
+        "number_of_shards": 1,
         "analysis": {
           "normalizer": {
             "custom": {

--- a/terraform_create_images/scripts/posvm/postproduction/elasticsearch/index_settings/genetics_evidence.json
+++ b/terraform_create_images/scripts/posvm/postproduction/elasticsearch/index_settings/genetics_evidence.json
@@ -26,7 +26,7 @@
   "settings": {
     "index": {
       "number_of_replicas": 0,
-      "number_of_shards": 5
+      "number_of_shards": 1
     }
   }
 }

--- a/terraform_create_images/scripts/posvm/postproduction/elasticsearch/index_settings/l2g_predictions.json
+++ b/terraform_create_images/scripts/posvm/postproduction/elasticsearch/index_settings/l2g_predictions.json
@@ -21,13 +21,16 @@
         },
         "score": {
           "type": "double"
+        },
+        "shapBaseValue": {
+          "type": "double"
         }
       }
     },
     "settings": {
         "index": {
             "number_of_replicas": 0,
-            "number_of_shards": 5
+            "number_of_shards": 1
         }
     }
 }

--- a/terraform_create_images/scripts/posvm/postproduction/elasticsearch/index_settings/search.json
+++ b/terraform_create_images/scripts/posvm/postproduction/elasticsearch/index_settings/search.json
@@ -27,7 +27,13 @@
   "settings": {
     "index": {
       "number_of_replicas": 0,
-      "number_of_shards": 5,
+      "number_of_shards": 1,
+      "similarity": {
+        "default": {
+          "type": "BM25",
+          "b": 0 
+        }
+      },
       "analysis": {
         "normalizer": {
           "custom": {

--- a/terraform_create_images/scripts/posvm/postproduction/elasticsearch/index_settings/search_known_drugs.json
+++ b/terraform_create_images/scripts/posvm/postproduction/elasticsearch/index_settings/search_known_drugs.json
@@ -27,7 +27,7 @@
   "settings": {
     "index": {
       "number_of_replicas": 0,
-      "number_of_shards": 5,
+      "number_of_shards": 1,
       "max_ngram_diff": 20,
       "analysis": {
         "normalizer": {

--- a/terraform_create_images/scripts/posvm/postproduction/elasticsearch/index_settings/study.json
+++ b/terraform_create_images/scripts/posvm/postproduction/elasticsearch/index_settings/study.json
@@ -239,7 +239,7 @@
     "settings": {
         "index": {
             "number_of_replicas": 0,
-            "number_of_shards": 5
+            "number_of_shards": 1
         }
     }
 }


### PR DESCRIPTION
- as part of opentargets/issues#3709
- update the mappings for l2g predictions elastic search index
- reduce number of shards for all elastic indices to 1 - avoids over-sharding and inconsistent scoring between shards
- set the bm25 similarity "b" variable to 0 to put zero weighting on the field length in the search index (defaults to 0.75 shorter fields -> higher relevance scores, which is not what we want)