### PR TITLE
refactor: croissant dataset input just the output folder

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -34,42 +34,5 @@ steps:
       ftp_address: http://ftp.ebi.ac.uk/pub/databases/opentargets/platform/${release}/output/
       gcp_address: gs://open-targets-data-releases/${release}/output/
       date_published: "2025-02-12"
-      dataset_paths:
-        - release_data/association_by_datasource_direct
-        - release_data/association_by_datasource_indirect
-        - release_data/association_by_datatype_direct
-        - release_data/association_by_datatype_indirect
-        - release_data/association_by_overall_indirect
-        - release_data/association_overall_direct
-        - release_data/biosample
-        - release_data/colocalisation_coloc
-        - release_data/colocalisation_ecaviar
-        - release_data/credible_set
-        - release_data/disease
-        - release_data/disease_hpo
-        - release_data/disease_phenotype
-        - release_data/drug_indication
-        - release_data/drug_mechanism_of_action
-        - release_data/drug_molecule
-        - release_data/drug_warning
-        - release_data/evidence
-        - release_data/expression
-        - release_data/go
-        - release_data/interaction
-        - release_data/interaction_evidence
-        - release_data/known_drug
-        - release_data/l2g_prediction
-        - release_data/literature
-        - release_data/literature_vector
-        - release_data/openfda_significant_adverse_drug_reactions
-        - release_data/openfda_significant_adverse_target_reactions
-        - release_data/pharmacogenomics
-        - release_data/reactome
-        - release_data/so
-        - release_data/study
-        - release_data/target
-        - release_data/target_essentiality
-        - release_data/target_prioritisation
-        - release_data/mouse_phenotype
-        - release_data/variant
+      dataset_path: release_data
       output: webapp/downloads.json

--- a/src/pos/tasks/ot_croissant.py
+++ b/src/pos/tasks/ot_croissant.py
@@ -4,6 +4,7 @@ import json
 from datetime import datetime
 from pathlib import Path
 from typing import Self
+import os
 
 from loguru import logger
 from ot_croissant.crumbs.metadata import PlatformOutputMetadata
@@ -38,7 +39,7 @@ class OtCroissantSpec(Spec):
 
     ftp_address: str
     gcp_address: str
-    dataset_paths: list[Path]
+    dataset_path: Path
     date_published: str
     output: str
 
@@ -66,7 +67,14 @@ class OtCroissant(Task):
 
         # Converting the list of paths to a list of strings and prepending the work_path
         logger.debug('converting the list of paths to a list of strings and prepending the work_path')
-        datasets = [str(self.context.config.work_path / p) for p in self.spec.dataset_paths]
+        # Get the directory path from self.spec.dataset_paths
+        directory_path = str(self.context.config.work_path / self.spec.dataset_path)
+
+        # List all sub-folders in the directory
+        datasets = [
+            str(self.context.config.work_path / self.spec.dataset_path / dataset)
+            for dataset in os.listdir(directory_path) if os.path.isdir(os.path.join(directory_path, dataset))
+        ]
 
         logger.debug(f'generating metadata for release {release}')
         metadata = PlatformOutputMetadata(


### PR DESCRIPTION
## Context

Upon running croissant step of POS for PPP, the `otar` dataset was missing. That was due to the fact that the pos step requires listing all input dataset for `ot_croissant`. Apparently this isproblematic, error prone and hard to maintain. Instead, POS is given the output directory containing the datasets. POS reads the included directories into a list and passes to ot_croissant.

