### PR TITLE
fix(clickhouse): drug synonyms/tradeNames are {label, source} struct arrays

### DIFF
--- a/config/clickhouse/schema/drug.sql
+++ b/config/clickhouse/schema/drug.sql
@@ -1,8 +1,18 @@
 CREATE TABLE IF NOT EXISTS drug_log (
     id String,
     name String,
-    synonyms Array (String),
-    tradeNames Array (String),
+    synonyms Array (
+        Tuple (
+            label String,
+            source String
+        )
+    ),
+    tradeNames Array (
+        Tuple (
+            label String,
+            source String
+        )
+    ),
     childChemblIds Array (String),
     drugType String,
     crossReferences Array (


### PR DESCRIPTION
## Summary

`drug_molecule`'s `synonyms` and `tradeNames` fields changed from `array<string>` to `array<struct<label, source>>` (opentargets/pts#142, tracking issue opentargets/issues#4414) — each name now carries provenance (`ChEMBL`, or `AACT` for names mined from clinical trials).

POS ingests `output/drug_molecule` directly into the `drug_log` ClickHouse table via `config/clickhouse/schema/drug.sql`, so the column DDL must match the parquet. Loading the new struct arrays into `Array(String)` columns would fail.

## What changed

`config/clickhouse/schema/drug.sql` — `synonyms` and `tradeNames` change from `Array(String)` to `Array(Tuple(label String, source String))`, mirroring the existing `crossReferences` tuple. The final `drug` table (`scripts/drug.sql`, `SELECT *`) inherits the new types, so nothing else changes.

## Scope (verified)

This is the only POS consequence:
- **OpenSearch** — there's no `drug_molecule` index; the drug dataset goes only to ClickHouse. `search_drug` is built from the flattened search dataset (`.label` strings, schema unchanged); `indication` doesn't carry these fields.
- **BigQuery / release** — parquet is copied / auto-detected; no explicit drug schema references these fields.
- No `src/` Python or other ClickHouse script references drug `synonyms`/`tradeNames`.

> ClickHouse matches `Tuple` elements to the parquet struct positionally; the parquet order is `{label, source}` (label first), which the DDL matches — consistent with the existing `crossReferences` tuple.
